### PR TITLE
Fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,7 +80,7 @@ linters:
     - usetesting
     - wastedassign
     - whitespace
-    # - wrapcheck
+    - wrapcheck
   disable-all: true
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
This pull request includes changes to the `client.go` file to improve error handling and context management, as well as a modification to the `.golangci.yml` configuration file to enable a specific linter.

Error handling and context management improvements:

* [`client.go`](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR44-L46): Added a default case to handle unsupported Redis client types in the `Wrap` function, including a panic with a descriptive error message.
* [`client.go`](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL129-R133): Updated the `processPipeline` function to use a new `pipelineCtx` for better context management when starting spans for Redis commands. [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL129-R133) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL139-R142)

Configuration updates:

* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L83-R83): Enabled the `wrapcheck` linter by uncommenting it in the `linters` section.